### PR TITLE
typo

### DIFF
--- a/TP/TP2Permutations.ipynb
+++ b/TP/TP2Permutations.ipynb
@@ -368,7 +368,7 @@
     "assert(rank([1,2,3],[3,2,1]) == 5)\n",
     "assert(rank([1,2,3],[1,3,2]) == 1)\n",
     "assert(rank([2,3,4],[2,4,3]) == 1)\n",
-    "assert([rank([1,2,3,4],p) for p in permutations_lex([1,2,3,4])] == range(24) )"
+    "assert([rank([1,2,3,4],p) for p in permutations_lex([1,2,3,4])] == list(range(24)))"
    ]
   },
   {


### PR DESCRIPTION
Test of TP-2 RANK do not pass because it assert that a list is equal toa generator.


**Edit**: it's a python3 / python2 issue, no relevant here.